### PR TITLE
Actualización de repositorio en pom.xml debido a un movimiento de maven de japer report 6.7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,10 @@
    
     <repositories>
         <repository>
+            <id>jaspersoft-third-party</id>
+            <url>https://jaspersoft.jfrog.io/jaspersoft/third-party-ce-artifacts/</url>
+        </repository>
+        <repository>
             <id>jitpack.io</id>
             <url>https://jitpack.io</url>
         </repository>

--- a/src/main/java/org/jugnicaragua/app/pico/vista/VentanaPrincipal.java
+++ b/src/main/java/org/jugnicaragua/app/pico/vista/VentanaPrincipal.java
@@ -1,5 +1,7 @@
 package org.jugnicaragua.app.pico.vista;
 
+import org.jugnicaragua.app.pico.vista.menu.MenuPrincipal;
+
 import javax.swing.*;
 import javax.swing.border.BevelBorder;
 import java.awt.*;

--- a/src/main/resources/hibernate.cfg.xml
+++ b/src/main/resources/hibernate.cfg.xml
@@ -17,7 +17,7 @@
         <!-- En desarrollo una conecction pool  
         <property name="hibernate.connection.pool_size">2</property>  -->  
               
-        <mapping class="org.jugni.apps.pico.modelos.MiEmpresa"/>
-        <mapping class="org.jugni.apps.pico.modelos.CuentaTipo"/>
+        <mapping class="org.jugni.apps.pico.modelo.MiEmpresa"/>
+        <mapping class="org.jugni.apps.pico.modelo.CuentaTipo"/>
     </session-factory>
 </hibernate-configuration>


### PR DESCRIPTION
En #69 incluí un error de implementación del proyecto, el cual se corrigió al agregar el repositorio al pom.xml, detalles realizados en este pull request:
- [x] Modificación del pom.xml al agregar un repositorio que permita descargar las dependencias de jasper report 6.7.0
- [x] Modificación de los paquetes a los cuales hace referencia el hibernate.cfg.utils
- [x] Para poder ejecutar la clase MenuPrincipal me pidió importarla